### PR TITLE
Trivial Hotfix for new savegameVersion 8. Until now, i could not disc…

### DIFF
--- a/src/main/java/qowyn/ark/ArkSavegame.java
+++ b/src/main/java/qowyn/ark/ArkSavegame.java
@@ -165,7 +165,7 @@ public class ArkSavegame implements GameObjectContainer {
       nameTableOffset = archive.getInt();
       propertiesBlockOffset = archive.getInt();
       gameTime = archive.getFloat();
-    } else if (saveVersion == 7) {
+    } else if (saveVersion == 7 || saveVersion == 8) {
       binaryDataOffset = archive.getInt();
       int shouldBeZero = archive.getInt();
       if (shouldBeZero != 0) {


### PR DESCRIPTION
Trivial Hotfix for new savegameVersion 8. Until now, i could not discover any changes to version 7. Maybe version was only raised for official release version of ark?

Example build with hotfix applied can be found at [https://ark.bienerd.de/pages/ark-tools-hotfix.html](https://ark.bienerd.de/pages/ark-tools-hotfix.html).

Many thanks for creating ark-savegame-toolkit and ark-tools - you really rock!

Kind Regards - b13n3rd