### PR TITLE
Fixes known structure parsing

### DIFF
--- a/src/main/java/qowyn/ark/arrays/ArkArrayStruct.java
+++ b/src/main/java/qowyn/ark/arrays/ArkArrayStruct.java
@@ -48,7 +48,7 @@ public class ArkArrayStruct extends ArrayList<Struct> implements ArkArray<Struct
   }
 
   public ArkArrayStruct(JsonNode node, PropertyArray property) {
-    int size = property.getDataSize();
+    int size = node.size();
 
     ArkName structType = StructRegistry.mapArrayNameToTypeName(property.getName());
     if (structType == null) {


### PR DESCRIPTION
Fixes the detection of known struct types (colors/vectors) and prevents a `NullPointerException` that was occurring as a result of the issue.